### PR TITLE
Fix bug when using version with Plug.conn.

### DIFF
--- a/lib/browser.ex
+++ b/lib/browser.ex
@@ -84,7 +84,8 @@ defmodule Browser do
     end
   end
 
-  def version(ua) do
+  def version(input) do
+    ua = Ua.to_ua(input)
     if ie?(ua) do
       ie_version(ua)
     else

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Browser.Mixfile do
 
   def project do
     [app: :browser,
-     version: "0.1.2",
+     version: "0.1.3",
      name: "browser",
      source_url: "https://github.com/tuvistavie/elixir-browser",
      homepage_url: "https://github.com/tuvistavie/elixir-browser",


### PR DESCRIPTION
Allow the ability to pass Plug.conn into the version def, similar to full_version
