### PR TITLE
Fix bug caused by nil UA when user-agent header isn't present

### DIFF
--- a/lib/browser.ex
+++ b/lib/browser.ex
@@ -13,7 +13,12 @@ defmodule Browser do
 
   defimpl Ua, for: Plug.Conn do
     def to_ua(conn) do
-      Plug.Conn.get_req_header(conn, "user-agent") |> List.first
+      conn
+      |> Plug.Conn.get_req_header("user-agent")
+      |> case do
+        []     -> ""
+        [h|_t] -> h
+      end
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,8 +34,11 @@ defmodule Browser.Mixfile do
   end
 
   defp deps do
-    [{:earmark, "~> 0.2", only: :dev},
-     {:ex_doc, "~> 0.12", only: :dev},
-     {:mix_test_watch, "~> 0.2", only: :dev}]
+    [
+      {:plug, "~> 1.2"},
+      {:earmark, "~> 0.2", only: :dev},
+      {:ex_doc, "~> 0.12", only: :dev},
+      {:mix_test_watch, "~> 0.2", only: :dev}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]}}
+  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
+  "plug": {:hex, :plug, "1.2.1", "dc878eb303099c945465b3f7811200e7dc0a4e2b1b6f3e26dc749011f3ed27ad", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]}}

--- a/test/browser_test.exs
+++ b/test/browser_test.exs
@@ -1,6 +1,21 @@
 defmodule BrowserTest do
   use ExUnit.Case
+  use Plug.Test
+  import Plug.Conn
+  alias Browser.Ua
   doctest Browser
+
+  test "returns empty string when Conn has no user-agent header" do
+    assert conn(:get, "/") |> Ua.to_ua == ""
+  end
+
+  test "retrieves first UA when Conn has user-agent header" do
+    conn = conn(:get, "/")
+      |> put_req_header("user-agent", "Mozilla 5.0")
+      |> put_req_header("user-agent", "Opera")
+
+    assert conn |> Ua.to_ua == "Opera"
+  end
 
   test "detects android" do
     ua = Fixtures.ua["ANDROID"]


### PR DESCRIPTION
Hi @tuvistavie,

I've fixed a small bug that's causing `nil`-related issues when the `user-agent` isn't present. `Ua.to_ua(conn)` now defaults to an empty string when the header doesn't exist.
