### PR TITLE
Option to customize bots list

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,14 @@ be extracted and used.
 ```elixir
 Browser.bot?(conn)
 ```
+
+### Configuration
+
+You can specify custom bots.txt file in your project's config.
+
+```elixir
+config :browser,
+  bots_file: Path.join(File.cwd!, "bots.txt")  # bots.txt in project's root
+```
+
+Please note that option set as mobule attribute during compile time, so make sure you recompiled elixir-browser after changing this option or bots file itself.

--- a/lib/browser.ex
+++ b/lib/browser.ex
@@ -208,7 +208,8 @@ defmodule Browser do
   end
 
   # Bot
-  @bots Browser.Helpers.read_file("bots.txt")
+  @bots_file Application.get_env(:browser, :bots_file, "bots.txt")
+  @bots Browser.Helpers.read_file(@bots_file)
   @search_engines Browser.Helpers.read_file("search_engines.txt")
 
   def bot?(input, options \\ []) do

--- a/lib/browser/helpers.ex
+++ b/lib/browser/helpers.ex
@@ -1,6 +1,6 @@
 defmodule Browser.Helpers do
   def read_file(name) do
-    File.read!(Path.join(Path.dirname(Path.dirname(__DIR__)), name))
+    File.read!(Path.expand(name))
       |> String.strip
       |> String.split("\n")
       |> Enum.map(&String.split(&1, "\t"))


### PR DESCRIPTION
In some cases you need to customize bots list to exclude some of the bots. In my particular example I need to remove Pinterest because Pinterest Webview on Android detected as bot.