### PR TITLE
Detect new Edge based on Chromium

### DIFF
--- a/lib/browser.ex
+++ b/lib/browser.ex
@@ -49,7 +49,7 @@ defmodule Browser do
   ]
 
   @versions %{
-    edge: ~r{Edge/([\d.]+)},
+    edge: ~r{(?:Edge|Edg)/([\d.]+)},
     chrome: ~r{(?:Chrome|CriOS)/([\d.]+)},
     default: ~r{(?:Version|MSIE|Firefox|QuickTime|BlackBerry[^/]+|CoreMedia v|PhantomJS|AdobeAIR|GSA|UCBrowser)[/ ]?([a-z0-9.]+)}i,
     opera: ~r{(?:Opera/.*? Version/([\d.]+)|Chrome/.*?OPR/([\d.]+))},
@@ -363,7 +363,7 @@ defmodule Browser do
   @trident_version_regex ~r{Trident/([0-9.]+)}
   @modern_ie ~r{Trident/.*?; rv:(.*?)}
   @msie ~r{MSIE ([\d.]+)|Trident/.*?; rv:([\d.]+)}
-  @edge ~r{(Edge/[\d.]+|Trident/8)}
+  @edge ~r{((Edge|Edg)/[\d.]+|Trident/8)}
   @trident_mapping %{
     "4.0" => "8",
     "5.0" => "9",


### PR DESCRIPTION
Microsoft Edge was recently updated to be based on Chromium, the user-agent includes the "Edg" string instead of the previos "Edge" one. For example:
```
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36 Edg/85.0.564.41
```

I've updated the corresponding regexes to properly recognize it as Edge instead of Chrome.