### PR TITLE
Fix warnings introduced with Elixir 1.14

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :plug,
   validate_header_keys_during_test: true

--- a/lib/browser.ex
+++ b/lib/browser.ex
@@ -250,9 +250,9 @@ defmodule Browser do
   end
 
   # Bot
-  @bots_file Application.get_env(:browser, :bots_file, "bots.txt")
+  @bots_file Application.compile_env(:browser, :bots_file, "bots.txt")
   @bots Browser.Helpers.read_file(@bots_file)
-  @bot_exceptions_file Application.get_env(:browser, :bot_exceptions_file, "bot_exceptions.txt")
+  @bot_exceptions_file Application.compile_env(:browser, :bot_exceptions_file, "bot_exceptions.txt")
   @bot_exceptions Browser.Helpers.read_file(@bot_exceptions_file)
   @search_engines Browser.Helpers.read_file("search_engines.txt")
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Browser.Mixfile do
      homepage_url: "https://github.com/danhper/elixir-browser",
      package: package(),
      description: description(),
-     elixir: "~> 1.3",
+     elixir: "~> 1.10",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps(),


### PR DESCRIPTION
Indulging in a satisfying yak shave.  Fixed some warnings.  Tested with latest OTP 26/Elixir 1.15.6

```
- `compile_env` should be used instead of `get_env` at module level to avoid silent corruption when run-time values conflict with compile-time
- use `import Config` instead of `use Mix.Config`
```